### PR TITLE
Bugfix: prevent that tags are deleted.

### DIFF
--- a/scripts/AzureFirewall/Set-AzFwState.ps1
+++ b/scripts/AzureFirewall/Set-AzFwState.ps1
@@ -51,14 +51,7 @@ Switch ($operation.ToLower()) {
                 PublicIPAddresses = $publicIPs
                 VirtualNetwork = $virtualNetworkName
                 resourceGroupName = $resourceGroupName
-            }
-            try {
-                write-verbose -message "Saving Information to Tag: FirewallInfo"
-                Set-AzResource -Tag @{FirewallInfo=($fwEntity | ConvertTo-Json)} -ResourceId $fwObject.Id -Force | out-null
-            }
-            catch {
-                throw "failed to save firewall information to Tags. skipping stop operation"
-            }
+            }            
         }
         catch {
             throw "Error while gathering current IP Configuration: $($_.Exception.Message)"
@@ -72,6 +65,14 @@ Switch ($operation.ToLower()) {
         }
         catch {
             throw "Error deallocating Azure Firewall: $($fwObject.Name). $($_.Exception.Message)"
+        }
+        
+        try {
+                write-verbose -message "Saving Information to Tag: FirewallInfo"
+                Set-AzResource -Tag @{FirewallInfo=($fwEntity | ConvertTo-Json)} -ResourceId $fwObject.Id -Force | out-null
+            }
+        catch {
+            throw "failed to save firewall information to Tags. skipping stop operation"
         }
     }
     "start" {


### PR DESCRIPTION
The following sequence does not work:
```

$fwObject = Get-AzFirewall -Name $firewallName
Set-AzResource -Tag @{FirewallInfo=($fwEntity | ConvertTo-Json)} -ResourceId $fwObject.Id -Force
Set-AzFirewall -AzureFirewall $fwObject
```

when performing line 3, we use the object as declared in line 1, which is without the new tag. So line 3 reverts the changes done in line 2. 

Possible solutions:
a) switch line 2 and 3 (proposed solution in the pull request)
b) replace line 2 so the code modifies the $fwObject.